### PR TITLE
fixed a 500 internal server error

### DIFF
--- a/streamviewer/server.py
+++ b/streamviewer/server.py
@@ -76,11 +76,16 @@ def stream(streamkey):
         # Stream was Missing, log warning
         running_since = None
         app.logger.info("Client {} looked for non-existent stream {}".format(request.remote_addr, streamkey))
-    else:
+    elif stream.active_since() is not None:
         existed = True
         app.logger.debug("Client requests stream {} ({}/{}.m3u8)".format(streamkey, config["application"]["hls_path"],  streamkey))
         running_since = humanize.naturaldelta(dt.timedelta(seconds=stream.active_since()))
         # Everything ok, return Stream
+    else:
+        # stream is broken in a different way, also server the not found/not started page
+        running_since = None
+        existed = False
+        app.logger.info("Client {} looked for non-existent stream {}".format(request.remote_addr, streamkey))
     return render_template('stream.html', application_name=APPLICATION_NAME, page_title=config["application"]["page_title"], hls_path=config["application"]["hls_path"], streamkey=streamkey, description=description, running_since=running_since, existed=existed)
 
 


### PR DESCRIPTION
When you accessed a stream that existed because it was in the config, but not streamed to, the active_since() would break the timedelta because it returned none.
this should do as a workaround

the error i received and fixed
`File "/srv/streamviewer/streamviewer/server.py", line 82, in stream
      running_since = humanize.naturaldelta(dt.timedelta(seconds=stream.active_since()))
      TypeError: unsupported type for timedelta seconds component: NoneType`